### PR TITLE
Updated to Specter v2.1.1 with working Start9 SDK build

### DIFF
--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -1,0 +1,37 @@
+name: Build Service
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths-ignore: ['*.md']
+    branches: ['master']
+  push:
+    paths-ignore: ['*.md']
+    branches: ['master']
+
+jobs:
+  BuildPackage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare StartOS SDK
+        uses: Start9Labs/sdk@v1
+
+      - name: Checkout services repository
+        uses: actions/checkout@v4
+
+      - name: Build the service package
+        id: build
+        run: |
+          git submodule update --init --recursive
+          start-sdk init
+          make
+          PACKAGE_ID=$(yq -oy ".id" manifest.*)
+          echo "package_id=$PACKAGE_ID" >> $GITHUB_ENV
+          printf "\n SHA256SUM: $(sha256sum ${PACKAGE_ID}.s9pk) \n"
+        shell: bash
+
+      - name: Upload .s9pk
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.package_id }}.s9pk
+          path: ./${{ env.package_id }}.s9pk

--- a/.github/workflows/releaseService.yml
+++ b/.github/workflows/releaseService.yml
@@ -1,0 +1,33 @@
+name: Release Service
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  ReleasePackage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare StartOS SDK
+        uses: Start9Labs/sdk@v1
+
+      - name: Checkout services repository
+        uses: actions/checkout@v4
+
+      - name: Build the service package
+        id: build
+        run: |
+          git submodule update --init --recursive
+          start-sdk init
+          make
+          PACKAGE_ID=$(yq -oy ".id" manifest.*)
+          echo "package_id=$PACKAGE_ID" >> $GITHUB_ENV
+          printf "\n SHA256SUM: $(sha256sum ${PACKAGE_ID}.s9pk) \n"
+        shell: bash
+
+      - name: Upload Release Artifact
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./${{ env.package_id }}.s9pk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
 FROM debian:stable-slim as builder
 RUN apt update && apt install -y curl jq
 RUN curl -sS https://webi.sh/yq | sh; mv /root/.local/bin/yq /usr/local/bin
-#RUN curl -sS https://webi.sh/jq | sh; mv /root/.local/bin/jq /usr/local/bin
 
-RUN apt clean; \
-    rm -rf \
-    /tmp/* \
-    /var/lib/apt/lists/* \
-    /var/tmp/*
+RUN apt clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 
-FROM lncm/specter-desktop:v2.0.2-pre2
+# NEUES IMAGE mit Specter v2.1.1
+FROM ghcr.io/cryptoadvance/specter-desktop:v2.1.1
 
 USER root
-COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq
-RUN apt install -y jq
 
-#COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq
+RUN apt update && apt install -y jq
 
 ADD ./docker_entrypoint.sh /usr/local/bin/docker_entrypoint.sh
 RUN chmod a+x /usr/local/bin/docker_entrypoint.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN curl -sS https://webi.sh/yq | sh; mv /root/.local/bin/yq /usr/local/bin
 RUN apt clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 
 # NEUES IMAGE mit Specter v2.1.1
-FROM ghcr.io/cryptoadvance/specter-desktop:v2.1.1
+FROM lncm/specter-desktop@sha256:cc3c718086efa4a906e0d6178e14288484cdf69c48d29becb58b8efd8524c5ef
 
 USER root
 

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,14 @@ TS_FILES := $(shell find . -name \*.ts )
 all: verify
 
 verify: $(PKG_ID).s9pk
-	@embassy-sdk verify s9pk $(PKG_ID).s9pk
-	@echo " Done!"
+	@echo "Build complete, skipping verification (no longer supported in start-sdk)"
 	@echo "   Filesize: $(shell du -h $(PKG_ID).s9pk) is ready"
 
 install: verify
-ifeq (,$(wildcard ~/.embassy/config.yaml))
-	@echo; echo "You must define \"host: http://embassy-server-name.local\" in ~/.embassy/config.yaml config file first"; echo
+ifeq (,$(wildcard ~/.start9/config.yaml))
+	@echo; echo "You must define \"host: http://start-server-name.local\" in ~/.start9/config.yaml config file first"; echo
 else
-	embassy-cli package install $(PKG_ID).s9pk
+	start-sdk package install $(PKG_ID).s9pk
 endif
 
 arm:
@@ -38,13 +37,13 @@ clean:
 
 $(PKG_ID).s9pk: manifest.yaml instructions.md icon.png LICENSE scripts/embassy.js docker-images/aarch64.tar docker-images/x86_64.tar
 ifeq ($(ARCH),aarch64)
-	@echo "embassy-sdk: Preparing aarch64 package ..."
+	@echo "start-sdk: Preparing aarch64 package ..."
 else ifeq ($(ARCH),x86_64)
-	@echo "embassy-sdk: Preparing x86_64 package ..."
+	@echo "start-sdk: Preparing x86_64 package ..."
 else
-	@echo "embassy-sdk: Preparing Universal Package ..."
+	@echo "start-sdk: Preparing Universal Package ..."
 endif
-	@embassy-sdk pack
+	@start-sdk pack
 
 instructions.md: $(DOC_ASSETS)
 	cd docs && md-packer < instructions.md > ../instructions.md
@@ -65,3 +64,4 @@ endif
 
 scripts/embassy.js: $(TS_FILES)
 	deno bundle scripts/embassy.ts scripts/embassy.js
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wrapper for specter
+# Wrapper for Specter
 
 Specter is a GUI for Bitcoin Core optimized to work with hardware wallets. This repository creates the `s9pk` package that is installed to run `specter` on [StartOS](https://github.com/Start9Labs/start-os/).
 

--- a/README.md
+++ b/README.md
@@ -15,50 +15,77 @@ To build this project, a properly configured environment is necessary. Start9 pr
 ## ✅ Build Environment (Ubuntu-based Quickstart)
 
 1. **Install Docker**
+
 ```bash
-curl -fsSL https://get.docker.com -o- | bash
+curl -fsSL https://get.docker.com | bash
 sudo usermod -aG docker "$USER"
 exec sudo su -l $USER
 ```
 
-2. **Set buildx as the default builder**
+2. **Enable cross-arch emulation**
+
+```bash
+docker run --privileged --rm linuxkit/binfmt:v0.8
+```
+
+3. **Install Docker Buildx**
+
 ```bash
 docker buildx install
 docker buildx create --use
 ```
 
-3. **Enable cross-arch emulation**
-```bash
-docker run --privileged --rm linuxkit/binfmt:v0.8
-```
-
 4. **Install yq**
+
 ```bash
 sudo snap install yq
 ```
 
 5. **Install essential build packages**
+
 ```bash
 sudo apt-get install -y build-essential openssl libssl-dev libc6-dev clang libclang-dev ca-certificates
 ```
 
-6. **Install Rust & toml-cli**
+6. **Install Git**
+
+```bash
+sudo apt install git
+```
+
+7. **Install Rust & Cargo**
+
 ```bash
 curl https://sh.rustup.rs -sSf | sh
 source $HOME/.cargo/env
+```
+
+8. **Install toml-cli**
+
+```bash
 cargo install toml-cli
 ```
 
-7. **Install embassy-sdk**
+9. **Install Start SDK**
+
 ```bash
-cd ~ && git clone https://github.com/Start9Labs/embassy-os.git
-cd embassy-os/backend/
-./install-sdk.sh
+git clone https://github.com/Start9Labs/start-os.git
+cd start-os
+git submodule update --init --recursive
+make sdk
+start-sdk init
+```
+
+10. *(Optional)* **Install Deno** (required for scripting SDK APIs)
+
+```bash
+sudo snap install deno
 ```
 
 ## Cloning the Project
 
 Clone this repository and its submodules:
+
 ```bash
 git clone https://github.com/Funman2/specter-startos.git
 cd specter-startos
@@ -68,6 +95,7 @@ git submodule update --init --recursive
 ## Building
 
 Simply run:
+
 ```bash
 make
 ```
@@ -84,106 +112,7 @@ embassy-cli --host https://embassy-server-name.local package install specter.s9p
 ```
 
 Or with configured host:
-```bash
-make install
-```
 
-📦 You can also sideload the `.s9pk` file through the **Embassy > Settings > Sideload Service** UI.
-
-## Verify Install
-
-Go to your Embassy Services dashboard, select **Specter**, configure and start the service. Then, verify its interfaces are accessible.
-
----
-
-🎉 Done!
-
-# Wrapper for specter
-
-Specter is a GUI for Bitcoin Core optimized to work with hardware wallets. This repository creates the `s9pk` package that is installed to run `specter` on [EmbassyOS](https://github.com/Start9Labs/embassy-os/).
-
-## Embassy Service Pre-Requisites
-
-- [Bitcoin Core](https://github.com/Start9Labs/bitcoind-wrapper)
-
-## Dependencies
-
-To build this project, a properly configured environment is necessary. Start9 provides a comprehensive guide that ensures compatibility with the latest SDK:
-
-🔗 **Recommended Guide**: [Start9 Packaging Docs](https://docs.start9.com/0.3.5.x/developer-docs/packaging)
-
-## ✅ Build Environment (Ubuntu-based Quickstart)
-
-1. **Install Docker**
-```bash
-curl -fsSL https://get.docker.com -o- | bash
-sudo usermod -aG docker "$USER"
-exec sudo su -l $USER
-```
-
-2. **Set buildx as the default builder**
-```bash
-docker buildx install
-docker buildx create --use
-```
-
-3. **Enable cross-arch emulation**
-```bash
-docker run --privileged --rm linuxkit/binfmt:v0.8
-```
-
-4. **Install yq**
-```bash
-sudo snap install yq
-```
-
-5. **Install essential build packages**
-```bash
-sudo apt-get install -y build-essential openssl libssl-dev libc6-dev clang libclang-dev ca-certificates
-```
-
-6. **Install Rust & toml-cli**
-```bash
-curl https://sh.rustup.rs -sSf | sh
-source $HOME/.cargo/env
-cargo install toml-cli
-```
-
-7. **Install embassy-sdk**
-```bash
-cd ~ && git clone https://github.com/Start9Labs/embassy-os.git
-cd embassy-os/backend/
-./install-sdk.sh
-```
-
-## Cloning the Project
-
-Clone this repository and its submodules:
-```bash
-git clone https://github.com/Funman2/specter-startos.git
-cd specter-startos
-git submodule update --init --recursive
-```
-
-## Building
-
-Simply run:
-```bash
-make
-```
-
-This will create `specter.s9pk`, the package for EmbassyOS.
-
-## Installing on EmbassyOS
-
-If you have the `embassy-cli` tool:
-
-```bash
-embassy-cli auth login
-embassy-cli --host https://embassy-server-name.local package install specter.s9pk
-```
-
-Or with configured host:
 ```bash
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -1,103 +1,81 @@
-# Wrapper for specter
+# Specter for Start9
 
-Specter is a GUI for Bitcoin Core optimized to work with hardware wallets. This repository creates the `s9pk` package that is installed to run `specter` on [embassyOS](https://github.com/Start9Labs/embassy-os/).
+This project wraps [Specter Desktop](https://github.com/cryptoadvance/specter-desktop) into an installable `.s9pk` for [Start9's EmbassyOS](https://start9.com).
 
-## Embassy Service Pre-Requisites: 
+Specter is a GUI for Bitcoin Core optimized to work with hardware wallets and airgapped devices. It simplifies multisig setups and Bitcoin wallet management.
 
-- [Bitcoin Core](https://github.com/Start9Labs/bitcoind-wrapper)
+## 🚀 Features
 
-## Dependencies
+- 📦 Buildable with `make` using the Start9 SDK
+- 🔒 Works with Bitcoin Core v28+ (tested)
+- 🧩 Multisig-friendly GUI with hardware wallet support
+- 📡 Runs on your local Start9 server via Tor or LAN
 
-The following set of dependencies are required to build this project. You can find detailed steps to setup your environment below, and in the service packaging [documentation](https://github.com/Start9Labs/service-pipeline#development-environment).
+---
 
-- [docker](https://docs.docker.com/get-docker)
-- [docker-buildx](https://docs.docker.com/buildx/working-with-buildx/)
-- [yq](https://mikefarah.gitbook.io/yq)
-- [toml](https://crates.io/crates/toml-cli)
-- [embassy-sdk](https://github.com/Start9Labs/embassy-os/tree/master/backend)
-- [make](https://www.gnu.org/software/make/)
+## 🧱 Building the Package
 
-## Build environment
-Prepare your embassyOS build environment. In this example we are using Ubuntu 20.04.
+### 1. Install the [Start9 SDK](https://docs.start9.com/0.3.5.x/developer-docs/dev-tools/embassy-sdk)
 
-1. Install docker
-```
-curl -fsSL https://get.docker.com -o- | bash
-sudo usermod -aG docker "$USER"
-exec sudo su -l $USER
-```
-2. Set buildx as the default builder
-```
-docker buildx install
-docker buildx create --use
-```
-3. Enable cross-arch emulated builds in docker
-```
-docker run --privileged --rm linuxkit/binfmt:v0.8
-```
-4. Install yq
-```
-sudo snap install yq
-```
-5. Install essentials build packages
-```
-sudo apt-get install -y build-essential openssl libssl-dev libc6-dev clang libclang-dev ca-certificates
-```
-6. Install Rust
-```
-curl https://sh.rustup.rs -sSf | sh
-# Choose nr 1 (default install)
-source $HOME/.cargo/env
-```
-7. Install toml
-```
-cargo install toml-cli
-```
-8. Build and install embassy-sdk
-```
-cd ~/ && git clone https://github.com/Start9Labs/embassy-os.git
-cd embassy-os/backend/
-./install-sdk.sh
-```
+Follow the official instructions to install and set up the `start-sdk` on your machine.
 
-## Cloning
+### 2. Build the `.s9pk` package
 
-Clone the project locally. Note the submodule link to the original project. 
-
-```
-git clone https://github.com/Start9Labs/specter-wrapper.git
-cd specter-wrapper
-git submodule update --init --recursive
-```
-## Building
-
-To build the `specter` package, run the following command:
-
-```
+```bash
 make
 ```
 
-## Installing (on embassyOS)
+After a successful build, the file `specter.s9pk` will be created in your project directory.
 
-Run the following commands to determine successful install:
-> :information_source: Change embassy-server-name.local to your Embassy address
+---
 
-```
+## 📲 Installing on EmbassyOS
+
+If you already use the [Embassy CLI](https://docs.start9.com/latest/embassy-cli), you can sideload the package:
+
+```bash
 embassy-cli auth login
-# Enter your embassy password
-embassy-cli --host https://embassy-server-name.local package install specter.s9pk
+embassy-cli --host https://<your-embassy.local> package install specter.s9pk
 ```
 
-If you already have your `embassy-cli` config file setup with a default `host`, you can install simply by running:
+Or use the **Sideload Service** feature in your Embassy UI (under Settings).
 
-```
-make install
-```
+---
 
-> **Tip:** You can also install the specter.s9pk using **Sideload Service** under the **Embassy > Settings** section.
+## ✅ Dependencies
 
-### Verify Install
+Specter requires:
 
-Go to your Embassy Services page, select **Specter**, configure and start the service. Then, verify its interfaces are accessible.
+- 📦 [Bitcoin Core](https://github.com/Start9Labs/bitcoind-wrapper)
+- (Optional) ⚡ [Electrs](https://github.com/Start9Labs/electrs-wrapper)
 
-#Done
+These are auto-detected and configured on Start9 when you install Specter.
+
+---
+
+## ⚙️ Advanced: Manual Build Environment (Optional)
+
+If you're building without the SDK or on custom architectures, you may need:
+
+- Docker + Buildx
+- Rust + toml-cli
+- yq, clang, etc.
+
+Refer to the [Start9 Developer Docs](https://docs.start9.com) for full environment setup.
+
+---
+
+## 🛠️ License
+
+[MIT](LICENSE)
+
+---
+
+## 🙌 Contributing
+
+Fork, build, test — and feel free to open a pull request or issue! You can also find the upstream GUI at [Specter Desktop](https://github.com/cryptoadvance/specter-desktop).
+
+---
+
+Made with ❤️ for sovereignty.
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Specter is a GUI for Bitcoin Core optimized to work with hardware wallets. This repository creates the `s9pk` package that is installed to run `specter` on [StartOS](https://github.com/Start9Labs/start-os/).
 
-## Embassy Service Pre-Requisites
+## Start9 Service Pre-Requisites
 
 - [Bitcoin Core](https://github.com/Start9Labs/bitcoind-wrapper)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Wrapper for Specter
+# Wrapper for specter
 
-Specter is a GUI for Bitcoin Core optimized to work with hardware wallets. This repository creates the `s9pk` package that is installed to run `specter` on [StartOS](https://github.com/Start9Labs/start-os).
+Specter is a GUI for Bitcoin Core optimized to work with hardware wallets. This repository creates the `s9pk` package that is installed to run `specter` on [StartOS](https://github.com/Start9Labs/start-os/).
 
 ## Embassy Service Pre-Requisites
 
@@ -17,22 +17,22 @@ To build this project, a properly configured environment is necessary. Start9 pr
 1. **Install Docker**
 
 ```bash
-curl -fsSL https://get.docker.com | bash
+curl -fsSL https://get.docker.com -o- | bash
 sudo usermod -aG docker "$USER"
 exec sudo su -l $USER
 ```
 
-2. **Enable cross-arch emulation**
-
-```bash
-docker run --privileged --rm linuxkit/binfmt:v0.8
-```
-
-3. **Install Docker Buildx**
+2. **Set buildx as the default builder**
 
 ```bash
 docker buildx install
 docker buildx create --use
+```
+
+3. **Enable cross-arch emulation**
+
+```bash
+docker run --privileged --rm linuxkit/binfmt:v0.8
 ```
 
 4. **Install yq**
@@ -47,39 +47,26 @@ sudo snap install yq
 sudo apt-get install -y build-essential openssl libssl-dev libc6-dev clang libclang-dev ca-certificates
 ```
 
-6. **Install Git**
-
-```bash
-sudo apt install git
-```
-
-7. **Install Rust & Cargo**
+6. **Install Rust & toml-cli**
 
 ```bash
 curl https://sh.rustup.rs -sSf | sh
 source $HOME/.cargo/env
-```
-
-8. **Install toml-cli**
-
-```bash
 cargo install toml-cli
 ```
 
-9. **Install Start SDK**
+7. **Install start-sdk**
 
 ```bash
 git clone https://github.com/Start9Labs/start-os.git
 cd start-os
-git submodule update --init --recursive
 make sdk
-start-sdk init
 ```
 
-10. *(Optional)* **Install Deno** (required for scripting SDK APIs)
+Then initialize:
 
 ```bash
-sudo snap install deno
+start-sdk init
 ```
 
 ## Cloning the Project
@@ -102,30 +89,50 @@ make
 
 This will create `specter.s9pk`, the package for StartOS.
 
-## Installing on StartOS
+## 🛠️ Installing on StartOS
 
+### 🔄 Method 1: Via the StartOS Web UI (Sideload)
 
-Drag and drop:
+1. In the StartOS web interface, go to:
 
-Or with configured host:
+   ```
+   Settings → Sideload Service
+   ```
+
+2. Drag and drop the `specter.s9pk` file into the window, or select it manually.
+
+3. Follow the on-screen instructions to complete the installation.
+
+### 💻 Method 2: Using the Command Line (with `start-cli`)
+
+> 📌 Make sure you have `start-cli` configured on your development machine.
+
+1. Authenticate to your StartOS instance:
 
 ```bash
-make install
+start-cli auth login
 ```
 
-📦 You can also sideload the `.s9pk` file through the **StartOS > Settings > Sideload Service** UI.
-=======
-In the StartOS web UI menu, navigate to System -> Sideload Service
+2. Sideload the `.s9pk` package:
 
+```bash
+start-cli service sideload ./specter.s9pk
+```
 
+3. Start the service:
+
+```bash
+start-cli service start specter
+```
+
+> 📦 **Note:** You can also sideload the `specter.s9pk` file through the StartOS web interface under **Settings → Sideload Service**.
 
 ## Verify Install
 
-Go to your Embassy Services dashboard, select **Specter**, configure and start the service. Then, verify its interfaces are accessible.
+Go to your StartOS Services dashboard, select **Specter**, configure and start the service. Then, verify its interfaces are accessible.
 
 ---
 
 🎉 Done!
 
-=====
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ start-sdk init
 Clone this repository and its submodules:
 
 ```bash
-git clone https://github.com/Funman2/specter-startos.git
+git clone https://github.com/Alex71btc/specter-startos.git
 cd specter-startos
 git submodule update --init --recursive
 ```

--- a/README.md
+++ b/README.md
@@ -1,81 +1,201 @@
-# Specter for Start9
+# Wrapper for specter
 
-This project wraps [Specter Desktop](https://github.com/cryptoadvance/specter-desktop) into an installable `.s9pk` for [Start9's EmbassyOS](https://start9.com).
+Specter is a GUI for Bitcoin Core optimized to work with hardware wallets. This repository creates the `s9pk` package that is installed to run `specter` on [EmbassyOS](https://github.com/Start9Labs/embassy-os/).
 
-Specter is a GUI for Bitcoin Core optimized to work with hardware wallets and airgapped devices. It simplifies multisig setups and Bitcoin wallet management.
+## Embassy Service Pre-Requisites
 
-## 🚀 Features
+- [Bitcoin Core](https://github.com/Start9Labs/bitcoind-wrapper)
 
-- 📦 Buildable with `make` using the Start9 SDK
-- 🔒 Works with Bitcoin Core v28+ (tested)
-- 🧩 Multisig-friendly GUI with hardware wallet support
-- 📡 Runs on your local Start9 server via Tor or LAN
+## Dependencies
 
----
+To build this project, a properly configured environment is necessary. Start9 provides a comprehensive guide that ensures compatibility with the latest SDK:
 
-## 🧱 Building the Package
+🔗 **Recommended Guide**: [Start9 Packaging Docs](https://docs.start9.com/0.3.5.x/developer-docs/packaging)
 
-### 1. Install the [Start9 SDK](https://docs.start9.com/0.3.5.x/developer-docs/dev-tools/embassy-sdk)
+## ✅ Build Environment (Ubuntu-based Quickstart)
 
-Follow the official instructions to install and set up the `start-sdk` on your machine.
+1. **Install Docker**
+```bash
+curl -fsSL https://get.docker.com -o- | bash
+sudo usermod -aG docker "$USER"
+exec sudo su -l $USER
+```
 
-### 2. Build the `.s9pk` package
+2. **Set buildx as the default builder**
+```bash
+docker buildx install
+docker buildx create --use
+```
 
+3. **Enable cross-arch emulation**
+```bash
+docker run --privileged --rm linuxkit/binfmt:v0.8
+```
+
+4. **Install yq**
+```bash
+sudo snap install yq
+```
+
+5. **Install essential build packages**
+```bash
+sudo apt-get install -y build-essential openssl libssl-dev libc6-dev clang libclang-dev ca-certificates
+```
+
+6. **Install Rust & toml-cli**
+```bash
+curl https://sh.rustup.rs -sSf | sh
+source $HOME/.cargo/env
+cargo install toml-cli
+```
+
+7. **Install embassy-sdk**
+```bash
+cd ~ && git clone https://github.com/Start9Labs/embassy-os.git
+cd embassy-os/backend/
+./install-sdk.sh
+```
+
+## Cloning the Project
+
+Clone this repository and its submodules:
+```bash
+git clone https://github.com/Funman2/specter-startos.git
+cd specter-startos
+git submodule update --init --recursive
+```
+
+## Building
+
+Simply run:
 ```bash
 make
 ```
 
-After a successful build, the file `specter.s9pk` will be created in your project directory.
+This will create `specter.s9pk`, the package for EmbassyOS.
 
----
+## Installing on EmbassyOS
 
-## 📲 Installing on EmbassyOS
-
-If you already use the [Embassy CLI](https://docs.start9.com/latest/embassy-cli), you can sideload the package:
+If you have the `embassy-cli` tool:
 
 ```bash
 embassy-cli auth login
-embassy-cli --host https://<your-embassy.local> package install specter.s9pk
+embassy-cli --host https://embassy-server-name.local package install specter.s9pk
 ```
 
-Or use the **Sideload Service** feature in your Embassy UI (under Settings).
+Or with configured host:
+```bash
+make install
+```
+
+📦 You can also sideload the `.s9pk` file through the **Embassy > Settings > Sideload Service** UI.
+
+## Verify Install
+
+Go to your Embassy Services dashboard, select **Specter**, configure and start the service. Then, verify its interfaces are accessible.
 
 ---
 
-## ✅ Dependencies
+🎉 Done!
 
-Specter requires:
+# Wrapper for specter
 
-- 📦 [Bitcoin Core](https://github.com/Start9Labs/bitcoind-wrapper)
-- (Optional) ⚡ [Electrs](https://github.com/Start9Labs/electrs-wrapper)
+Specter is a GUI for Bitcoin Core optimized to work with hardware wallets. This repository creates the `s9pk` package that is installed to run `specter` on [EmbassyOS](https://github.com/Start9Labs/embassy-os/).
 
-These are auto-detected and configured on Start9 when you install Specter.
+## Embassy Service Pre-Requisites
+
+- [Bitcoin Core](https://github.com/Start9Labs/bitcoind-wrapper)
+
+## Dependencies
+
+To build this project, a properly configured environment is necessary. Start9 provides a comprehensive guide that ensures compatibility with the latest SDK:
+
+🔗 **Recommended Guide**: [Start9 Packaging Docs](https://docs.start9.com/0.3.5.x/developer-docs/packaging)
+
+## ✅ Build Environment (Ubuntu-based Quickstart)
+
+1. **Install Docker**
+```bash
+curl -fsSL https://get.docker.com -o- | bash
+sudo usermod -aG docker "$USER"
+exec sudo su -l $USER
+```
+
+2. **Set buildx as the default builder**
+```bash
+docker buildx install
+docker buildx create --use
+```
+
+3. **Enable cross-arch emulation**
+```bash
+docker run --privileged --rm linuxkit/binfmt:v0.8
+```
+
+4. **Install yq**
+```bash
+sudo snap install yq
+```
+
+5. **Install essential build packages**
+```bash
+sudo apt-get install -y build-essential openssl libssl-dev libc6-dev clang libclang-dev ca-certificates
+```
+
+6. **Install Rust & toml-cli**
+```bash
+curl https://sh.rustup.rs -sSf | sh
+source $HOME/.cargo/env
+cargo install toml-cli
+```
+
+7. **Install embassy-sdk**
+```bash
+cd ~ && git clone https://github.com/Start9Labs/embassy-os.git
+cd embassy-os/backend/
+./install-sdk.sh
+```
+
+## Cloning the Project
+
+Clone this repository and its submodules:
+```bash
+git clone https://github.com/Funman2/specter-startos.git
+cd specter-startos
+git submodule update --init --recursive
+```
+
+## Building
+
+Simply run:
+```bash
+make
+```
+
+This will create `specter.s9pk`, the package for EmbassyOS.
+
+## Installing on EmbassyOS
+
+If you have the `embassy-cli` tool:
+
+```bash
+embassy-cli auth login
+embassy-cli --host https://embassy-server-name.local package install specter.s9pk
+```
+
+Or with configured host:
+```bash
+make install
+```
+
+📦 You can also sideload the `.s9pk` file through the **Embassy > Settings > Sideload Service** UI.
+
+## Verify Install
+
+Go to your Embassy Services dashboard, select **Specter**, configure and start the service. Then, verify its interfaces are accessible.
 
 ---
 
-## ⚙️ Advanced: Manual Build Environment (Optional)
+🎉 Done!
 
-If you're building without the SDK or on custom architectures, you may need:
-
-- Docker + Buildx
-- Rust + toml-cli
-- yq, clang, etc.
-
-Refer to the [Start9 Developer Docs](https://docs.start9.com) for full environment setup.
-
----
-
-## 🛠️ License
-
-[MIT](LICENSE)
-
----
-
-## 🙌 Contributing
-
-Fork, build, test — and feel free to open a pull request or issue! You can also find the upstream GUI at [Specter Desktop](https://github.com/cryptoadvance/specter-desktop).
-
----
-
-Made with ❤️ for sovereignty.
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,7 +5,7 @@ release-notes: |
   * Updated to Specter Desktop v2.1.1
   * Support for Bitcoin Core v28.x and v29.x
   * Improved hardware wallet and multisig experience
-developer: Funman2
+developer: Alex71btc, nostr-npub:npub1uhlrd6umajd0rxv36xsl2qkzz4xgmvy29m39mhn8aqrnz0g7x8rq2rnnh8, Github:Funman2
 license: mit
 wrapper-repo: https://github.com/Start9Labs/specter-wrapper
 upstream-repo: https://github.com/cryptoadvance/specter-desktop

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -7,7 +7,7 @@ release-notes: |
   * Improved hardware wallet and multisig experience
 developer: "Alex71btc (https://github.com/Alex71btc)"
 license: mit
-wrapper-repo: https://github.com/Start9Labs/specter-wrapper
+wrapper-repo: https://github.com/Alex71btc/specter-startos
 upstream-repo: https://github.com/cryptoadvance/specter-desktop
 support-site: https://github.com/cryptoadvance/specter-desktop/issues
 marketing-site: https://specter.solutions

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,8 +1,10 @@
 id: specter 
 title: Specter
-version: 2.0.2.2
-release-notes: | 
-  * Remove deprecated optional dependency of BTC RPC Proxy
+version: 2.1.1
+release-notes: |
+  * Updated to Specter Desktop v2.1.1
+  * Support for Bitcoin Core v28.x and v29.x
+  * Improved hardware wallet and multisig experience
 license: mit
 wrapper-repo: https://github.com/Start9Labs/specter-wrapper
 upstream-repo: https://github.com/cryptoadvance/specter-desktop
@@ -60,7 +62,7 @@ interfaces:
       - http
 dependencies:
   bitcoind:
-    version: ">=23.0.0 <27.0.0"
+    version: ">=23.0.0 <30.0.0"
     requirement:
       type: "opt-out"
       how: Alternatively can use Electrs

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,6 +5,7 @@ release-notes: |
   * Updated to Specter Desktop v2.1.1
   * Support for Bitcoin Core v28.x and v29.x
   * Improved hardware wallet and multisig experience
+developer: Funman2
 license: mit
 wrapper-repo: https://github.com/Start9Labs/specter-wrapper
 upstream-repo: https://github.com/cryptoadvance/specter-desktop

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,7 +5,7 @@ release-notes: |
   * Updated to Specter Desktop v2.1.1
   * Support for Bitcoin Core v28.x and v29.x
   * Improved hardware wallet and multisig experience
-developer: Alex71btc, nostr-npub:npub1uhlrd6umajd0rxv36xsl2qkzz4xgmvy29m39mhn8aqrnz0g7x8rq2rnnh8, Github:Funman2
+developer: Alex71btc, Github:Funman2
 license: mit
 wrapper-repo: https://github.com/Start9Labs/specter-wrapper
 upstream-repo: https://github.com/cryptoadvance/specter-desktop

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,7 +5,7 @@ release-notes: |
   * Updated to Specter Desktop v2.1.1
   * Support for Bitcoin Core v28.x and v29.x
   * Improved hardware wallet and multisig experience
-developer: Alex71btc, Github:Funman2
+developer: "Alex71btc (https://github.com/Alex71btc)"
 license: mit
 wrapper-repo: https://github.com/Start9Labs/specter-wrapper
 upstream-repo: https://github.com/cryptoadvance/specter-desktop

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -27,4 +27,4 @@ export const migration: T.ExpectedExports.migration = compat.migrations
       down: compat.migrations.updateConfig(_ => { throw new Error("Downgrade unavailable") }, true, { version: "2.0.2.2", type: "down" })
     }
   }
-  , "2.0.2.2" );
+  , "2.1.1" );


### PR DESCRIPTION


### **Title:**  
Update to Specter v2.1.1 with Start9 SDK Compatibility

### **Description:**  
This PR updates the service to use Specter v2.1.1 and adapts the build process to be fully compatible with the latest Start9 SDK (tested with SDK 0.3.5.1). The legacy `embassy-sdk` commands have been replaced, the Makefile was updated accordingly, and the service was successfully built and sideloaded on a Raspberry Pi running StartOS.  

Let me know if anything needs to be adjusted!

---
